### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Distributed tests planner plugin for pytest testing framework
 
 .. image:: https://api.travis-ci.org/pytest-dev/pytest-cloud.png
     :target: https://travis-ci.org/pytest-dev/pytest-cloud
-.. image:: https://pypip.in/v/pytest-cloud/badge.png
+.. image:: https://img.shields.io/pypi/v/pytest-cloud.svg
     :target: https://crate.io/packages/pytest-cloud/
 .. image:: https://coveralls.io/repos/pytest-dev/pytest-cloud/badge.png?branch=master
     :target: https://coveralls.io/r/pytest-dev/pytest-cloud


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pytest-cloud))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pytest-cloud`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-cloud/8)
<!-- Reviewable:end -->
